### PR TITLE
Terraform and AWS Secrets Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Lets try to attempt...
 - [x] Manage IAM roles.. via [iamy](https://github.com/99designs/iamy)
 - [x] Get IAM role sync checks working in CI
 - [x] Drift detection (aws moves from code, when aws moves from cf definition..)
-- [ ] How to manage secrets eg private key / db password
+- [x] How to manage secrets eg private key / db password
 - [ ] ECS cluster / EKS setup / something with more complexity.
     - [ ] wip - [ecs maybe](http://blog.shippable.com/setup-a-container-cluster-on-aws-with-terraform-part-2-provision-a-cluster)
 - [ ] Bastion box to access VPC (maybe via [this?](https://aws.amazon.com/blogs/infrastructure-and-automation/toward-a-bastion-less-world/))
@@ -41,6 +41,7 @@ Fix Later..
 2. install checkov `pip install checkov`
 
 ## Repo Structure 🏛
+- [ ] TODO - explain directory structure.
  ```
 ├── README.md
 ├── global 
@@ -79,6 +80,13 @@ terraform apply
 More [info](https://www.terraform.io/docs/backends/).
 
 Yes this will create a local `.tfstate` file but it should only be needed to run once. (yeah chicken egg etc..)  
+
+## How to Manage Secrets
+### AWS
+Using AWS Secrets Manager to hold secrets. 
+Refer to [this](https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1#bebe) on how to add a secret.  
+There should be clear access roles also defined about who can access these secrets.
+- [ ] TODO Create a clear way to assign users permission to access and modify secrets.
 
 ## Helpful sites refrenced 
 https://blog.gruntwork.io/how-to-create-reusable-infrastructure-with-terraform-modules-25526d65f73d#ff91  

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Lets try to attempt...
 - [x] Manage IAM roles.. via [iamy](https://github.com/99designs/iamy)
 - [x] Get IAM role sync checks working in CI
 - [x] Drift detection (aws moves from code, when aws moves from cf definition..)
+    - [ ] Make script more dynamic for checks.
 - [x] How to manage secrets eg private key / db password
 - [ ] ECS cluster / EKS setup / something with more complexity.
     - [ ] wip - [ecs maybe](http://blog.shippable.com/setup-a-container-cluster-on-aws-with-terraform-part-2-provision-a-cluster)

--- a/global/IAM/580133377048/iam/user/travis-ci.yaml
+++ b/global/IAM/580133377048/iam/user/travis-ci.yaml
@@ -1,6 +1,7 @@
 Groups:
 - robots
 Policies:
+- arn:aws:iam::aws:policy/SecretsManagerReadWrite
 - arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
 - arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess
 - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess

--- a/prod/foo-app/main.tf
+++ b/prod/foo-app/main.tf
@@ -1,0 +1,4 @@
+# Set up backend to store .tfstate file
+# https://www.terraform.io/docs/backends/types/index.html
+# https://www.terraform.io/docs/backends/types/s3.html
+

--- a/prod/foo-app/main.tf
+++ b/prod/foo-app/main.tf
@@ -12,3 +12,9 @@ terraform {
   }
 }
 
+# TODO - ensure that secrets can only be access by roles that need them
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version
+data "aws_secretsmanager_secret_version" "foo_token" {
+  secret_id = var.foo_token_id
+}
+

--- a/prod/foo-app/main.tf
+++ b/prod/foo-app/main.tf
@@ -18,3 +18,7 @@ data "aws_secretsmanager_secret_version" "foo_token" {
   secret_id = var.foo_token_id
 }
 
+#TODO - how to ensure this is hidden in console output (esp for CI) 
+output "foo_token" {
+  value = data.aws_secretsmanager_secret_version.foo_token.secret_string
+}

--- a/prod/foo-app/main.tf
+++ b/prod/foo-app/main.tf
@@ -2,3 +2,13 @@
 # https://www.terraform.io/docs/backends/types/index.html
 # https://www.terraform.io/docs/backends/types/s3.html
 
+terraform {
+  required_version = "~> 0.12"
+  backend "s3" {
+    encrypt = true
+    bucket  = "joes-tf-state-encrypted"
+    key     = "prod/foo-app/terraform.tfstate"
+    region  = "ap-southeast-2"
+  }
+}
+

--- a/prod/foo-app/prod.tfvars
+++ b/prod/foo-app/prod.tfvars
@@ -1,0 +1,1 @@
+foo_token_id = "prod/some/token"

--- a/prod/foo-app/variables.tf
+++ b/prod/foo-app/variables.tf
@@ -1,0 +1,4 @@
+variable "foo_token_id" {
+  type        = string
+  description = "Secret Token"
+}

--- a/scripts/drift_checks.sh
+++ b/scripts/drift_checks.sh
@@ -10,6 +10,13 @@ wget --quiet "https://releases.hashicorp.com/terraform/$TF_VERSION/terraform_"$T
 unzip "terraform_"$TF_VERSION"_linux_amd64.zip"
 rm "terraform_"$TF_VERSION"_linux_amd64.zip"
 
+# TODO - Find a better synamic way to traverse the definitions and run the checks
+# rather than having to add them in here 1 by 1. 
+
 cd prod/vpc
+terraform init
+terraform plan -var-file=prod.tfvars -detailed-exitcode
+
+cd ../foo-app
 terraform init
 terraform plan -var-file=prod.tfvars -detailed-exitcode

--- a/scripts/drift_checks.sh
+++ b/scripts/drift_checks.sh
@@ -10,7 +10,7 @@ wget --quiet "https://releases.hashicorp.com/terraform/$TF_VERSION/terraform_"$T
 unzip "terraform_"$TF_VERSION"_linux_amd64.zip"
 rm "terraform_"$TF_VERSION"_linux_amd64.zip"
 
-# TODO - Find a better synamic way to traverse the definitions and run the checks
+# TODO - Find a better dynamic way to traverse the definitions and run the checks
 # rather than having to add them in here 1 by 1. 
 
 cd prod/vpc


### PR DESCRIPTION
## Context
I want to figure out what is a good default way to manage secrets when using Terraform to provision AWS Resources.

I found this [blog](https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1#3073) post helpful to understand the options.  
I chose to go with [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/)  outlined in this part of the [blog post](https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1#bebe) 

### Reasoning
In that post there are a list of really good advantages and disadvantages of all the approaches.
My main factor was not having to introduce another tool / system like [Vault](https://www.vaultproject.io/) - another thing to maintain 🥱 
There seems to be fairly similar services offered across the major cloud providers GCP Secrets Manager / Azure Key Vault .. If you are neck deep in a cloud providers services, why not just use a system already set up for secrets management rather than maintain your own. (Bonus.. this makes the secret easy to rotate as well!)

I would have been ok to GPG encrypt the `tfvar` files as well, top to bottom. Then there is risk of accidental check in..and I really couldn't be bothered explaining GPG encryption workflows in this repo. Feels like AWS Secrets Manager is a clearer way and should keep the secrets well out of git repos.