### PR TITLE
Terraform Outputs 

### DIFF
--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,4 +1,14 @@
-output "VPCId" {
+output "vpc_id" {
   description = "The ID of the VPC"
   value       = aws_vpc.main.id
+}
+
+output "private_subnet_a_id" {
+  description = "The ID of private subnet a"
+  value       = aws_subnet.private_subnet_a.id
+}
+
+output "private_subnet_b_id" {
+  description = "The ID of private subnet b"
+  value       = aws_subnet.private_subnet_b.id
 }

--- a/prod/vpc/outputs.tf
+++ b/prod/vpc/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.main_vpc.vpc_id
+}
+
+output "private_subnet_a_id" {
+  description = "The ID of private subnet a"
+  value       = module.main_vpc.private_subnet_a_id
+}
+
+output "private_subnet_b_id" {
+  description = "The ID of private subnet b"
+  value       = module.main_vpc.private_subnet_b_id
+}


### PR DESCRIPTION
# Context
When I was attempting to build another set of resource with outputs from the VPC stack I noticed that they were not in the terraform state file.
See [here](https://www.terraform.io/docs/configuration/outputs.html#accessing-child-module-outputs)
in Terraform 0.12 this is mentioned as a Major release with breaking changes. (?)

One change I discovered is that outputs can only be defined from the parent module. So for the vpc stack the 'root' or parent `maint.tf` is in that `prod/vpc` dir . The outputs were working from the vpc module but you need to reference them as described in the link above.. Essentially 'passing them through' from the child module to the parent directory.

Wish this was clearer in the documentation.